### PR TITLE
antipattern fixup (locking)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build_wii
 /build_gc
 /executables
+.DS_Store

--- a/source/video.h
+++ b/source/video.h
@@ -36,9 +36,9 @@ extern int screenwidth;
 extern bool progressive;
 extern u8 * gameScreenPng;
 extern int gameScreenPngSize;
-extern u32 FrameTimer;
+extern volatile u32 FrameTimer;
 extern bool vmode_60hz;
 extern int timerstyle;
-extern int CheckVideo;
+extern volatile int CheckVideo;
 
 #endif


### PR DESCRIPTION
trying to bughunt
This pull request improves thread safety and reduces race conditions in the video rendering code by marking several shared variables as `volatile`, and by using local snapshots of filter settings and function pointers within the `update_video` function. These changes help ensure consistent behavior when variables are accessed or modified by multiple threads, such as the render and menu threads.

**Thread safety improvements:**

* Marked `whichfb`, `CheckVideo`, `copynow`, and `FrameTimer` as `volatile` in `video.cpp` and `video.h` to ensure proper synchronization between threads that read and write these variables. [[1]](diffhunk://#diff-556af2554c9cfe3156dcaf9c60a5114a81a28d5182601e96c95facabc06c5c48L45-R50) [[2]](diffhunk://#diff-556af2554c9cfe3156dcaf9c60a5114a81a28d5182601e96c95facabc06c5c48L59-R59) [[3]](diffhunk://#diff-556af2554c9cfe3156dcaf9c60a5114a81a28d5182601e96c95facabc06c5c48L69-R69) [[4]](diffhunk://#diff-5556709b54e99493b0d2a490a2398519b92829f1fef1f3d79ad60a8e65bfcc81L39-R42)
* In `update_video`, created a local snapshot of `GCSettings.FilterMethod` (`filterIdLocal`) to minimize race conditions when the filter setting is updated by the menu thread. All filter-related logic now uses this local variable. [[1]](diffhunk://#diff-556af2554c9cfe3156dcaf9c60a5114a81a28d5182601e96c95facabc06c5c48R763-R765) [[2]](diffhunk://#diff-556af2554c9cfe3156dcaf9c60a5114a81a28d5182601e96c95facabc06c5c48L781-R784) [[3]](diffhunk://#diff-556af2554c9cfe3156dcaf9c60a5114a81a28d5182601e96c95facabc06c5c48L790-R793) [[4]](diffhunk://#diff-556af2554c9cfe3156dcaf9c60a5114a81a28d5182601e96c95facabc06c5c48L843-R846) [[5]](diffhunk://#diff-556af2554c9cfe3156dcaf9c60a5114a81a28d5182601e96c95facabc06c5c48L852-R860)
* Copied the `FilterMethod` function pointer to a local variable before invoking it, preventing possible race conditions if the pointer is changed by another thread during execution.